### PR TITLE
Use OpenStreeMap to display the map in the browser

### DIFF
--- a/app/src/main/java/org/toulibre/capitoledulibre/fragments/MapFragment.java
+++ b/app/src/main/java/org/toulibre/capitoledulibre/fragments/MapFragment.java
@@ -26,7 +26,8 @@ public class MapFragment extends Fragment {
 
     private static final String NATIVE_URI = "google.navigation:q=%1$f,%2$f&mode=d";
 
-    private static final Uri WEB_URI = Uri.parse("https://goo.gl/maps/atYtpUZCouy");
+    //private static final Uri WEB_URI_GOOGLE = Uri.parse("https://goo.gl/maps/atYtpUZCouy");
+    private static final Uri WEB_URI = Uri.parse("https://www.openstreetmap.org/way/22634781");
 
     @Override
     public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Use OpenStreetMap instead of Google Maps if Google Maps is not installed.